### PR TITLE
MIA-136: Update GitHub workflows to post to move-and-improve-alerts-non-prod

### DIFF
--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security npm dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_npm_dependency.yml@v2 # WORKFLOW_VERSION
     with:
-      channel_id: move-and-improve-alerts
+      channel_id: move-and-improve-alerts-non-prod
     secrets: inherit

--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security trivy dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_trivy.yml@v2 # WORKFLOW_VERSION
     with:
-      channel_id: move-and-improve-alerts
+      channel_id: move-and-improve-alerts-non-prod
     secrets: inherit

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security veracode pipeline scan
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_pipeline_scan.yml@v2 # WORKFLOW_VERSION
     with:
-      channel_id: move-and-improve-alerts
+      channel_id: move-and-improve-alerts-non-prod
     secrets: inherit

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security veracode policy scan
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_policy_scan.yml@v2 # WORKFLOW_VERSION
     with:
-      channel_id: move-and-improve-alerts
+      channel_id: move-and-improve-alerts-non-prod
     secrets: inherit


### PR DESCRIPTION
Update GitHub workflows to post to `move-and-improve-alerts-non-prod`