### PR TITLE
MIA-426 Segregate pages by policy (key-worker and personal-officer)

### DIFF
--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -6,6 +6,6 @@ declare namespace Cypress {
      */
     signIn(options?: { failOnStatusCode: boolean }): Chainable<string>
     verifyLastAPICall(matching: string | object, expected: object): Chainable<unknown>
-    injectJourneyDataAndReload<T>(uuid: string, json: T): void
+    injectJourneyDataAndReload<T>(uuid: string, json: T, policy?: string): void
   }
 }

--- a/integration_tests/mockApis/keyworkerApi.ts
+++ b/integration_tests/mockApis/keyworkerApi.ts
@@ -106,17 +106,17 @@ const stubKeyworkerPrisonConfig = (isEnabled: boolean, hasPrisonersWithHighCompl
   stubFor({
     request: {
       method: 'GET',
-      urlPathPattern: '/keyworker-api/prisons/LEI/configuration/keyworker',
+      urlPathPattern: '/keyworker-api/prisons/LEI/configurations',
     },
     response: {
       status: 200,
       jsonBody: {
         isEnabled,
         hasPrisonersWithHighComplexityNeeds,
-        allowAutoAllocate: true,
-        capacityTier1: 6,
-        capacityTier2: 9,
-        kwSessionFrequencyInWeeks: 1,
+        allowAutoAllocation: true,
+        capacity: 6,
+        maximumCapacity: 9,
+        frequencyInWeeks: 1,
       },
       headers: {
         'Content-Type': 'application/json',

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -10,7 +10,7 @@ type RecursivePartial<T> = T extends unknown
 export type PartialJourneyData = RecursivePartial<JourneyData>
 
 Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
-  cy.request('/')
+  cy.request('/key-worker')
   return cy.task<string>('getSignInUrl').then((url: string) => {
     cy.visit(url, options)
   })
@@ -20,8 +20,8 @@ Cypress.Commands.add('verifyLastAPICall', (matching: string | object, expected: 
   return cy.wrap(getLastAPICallMatching(matching)).should('deep.equal', expected)
 })
 
-Cypress.Commands.add('injectJourneyDataAndReload', <T>(uuid: string, json: T) => {
+Cypress.Commands.add('injectJourneyDataAndReload', <T>(uuid: string, json: T, policy: string = 'key-worker') => {
   const data = encodeURIComponent(btoa(JSON.stringify(json)))
-  cy.request('GET', `/${uuid}/inject-journey-data?data=${data}`)
+  cy.request('GET', `${policy}/${uuid}/inject-journey-data?data=${data}`)
   cy.reload()
 })

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -66,6 +66,7 @@ export declare global {
       middleware?: {
         prisonerData?: Prisoner
         policy?: 'KEY_WORKER' | 'PERSONAL_OFFICER'
+        prisonConfiguration?: components['schemas']['PrisonConfigResponse']
       }
     }
 
@@ -83,12 +84,12 @@ export declare global {
       breadcrumbs: Breadcrumbs
       prisoner?: PrisonerSummary
       policyName?: string
+      policyPath?: string
       buildNumber?: string
       asset_path: string
       applicationName: string
       environmentName: string
       environmentNameColour: string
-      prisonConfiguration: components['schemas']['PrisonKeyworkerConfiguration']
       feComponents?: {
         sharedData?: {
           activeCaseLoad: CaseLoad

--- a/server/app.ts
+++ b/server/app.ts
@@ -27,8 +27,6 @@ import sentryMiddleware from './middleware/sentryMiddleware'
 import routes from './routes'
 import type { Services } from './services'
 import populateClientToken from './middleware/populateSystemClientToken'
-import breadcrumbs from './middleware/breadcrumbs'
-import { populateUserPermissions } from './middleware/permissionsMiddleware'
 import populateValidationErrors from './middleware/populateValidationErrors'
 import PrisonerImageRoutes from './routes/prisonerImageRoutes'
 import { handleApiError } from './middleware/handleApiError'
@@ -75,7 +73,7 @@ export default function createApp(services: Services): express.Application {
     res.notFound = () => res.status(404).render('pages/not-found')
     next()
   })
-  app.use(breadcrumbs())
+
   app.use(dpsComponents.retrieveCaseLoadData({ logger }))
   app.use(populateValidationErrors())
 
@@ -84,8 +82,7 @@ export default function createApp(services: Services): express.Application {
     res.render('not-authorised', { showBreadcrumbs: true })
   })
 
-  app.use(populateUserPermissions())
-  app.use(routes(services))
+  app.use('/:policy', routes(services))
 
   if (config.sentry.dsn) Sentry.setupExpressErrorHandler(app)
 

--- a/server/middleware/breadcrumbs.ts
+++ b/server/middleware/breadcrumbs.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import { sentenceCase } from '../utils/formatUtils'
 
 export type Breadcrumb = { href: string } & ({ text: string } | { html: string })
 
@@ -12,8 +13,8 @@ export class Breadcrumbs {
         href: res.locals.digitalPrisonServicesUrl,
       },
       {
-        text: 'Key workers',
-        href: '/',
+        text: `${sentenceCase(res.locals.policyName!)}s`,
+        href: `/${res.locals.policyPath}`,
       },
     ]
   }

--- a/server/middleware/journey/insertJourneyIdentifier.ts
+++ b/server/middleware/journey/insertJourneyIdentifier.ts
@@ -3,7 +3,7 @@ import { v4 as uuidV4, validate } from 'uuid'
 
 export default function insertJourneyIdentifier() {
   return (req: Request, res: Response, next: NextFunction): void => {
-    const uuid = req.url.split('/')[1] || '/'
+    const uuid = req.url.split('/')[1]
     if (!validate(uuid)) {
       return res.redirect(`${req.baseUrl}/${uuidV4()}${req.url}`)
     }

--- a/server/middleware/permissionsMiddleware.ts
+++ b/server/middleware/permissionsMiddleware.ts
@@ -31,10 +31,25 @@ export function populateUserPermissions(): RequestHandler {
         allocate: hasRole(res, AuthorisedRoles.OMIC_ADMIN, AuthorisedRoles.KW_MIGRATION),
         admin: hasRole(res, AuthorisedRoles.KW_MIGRATION),
       }
+      req.middleware ??= {}
+      switch (req.params['policy']) {
+        case 'key-worker':
+          req.middleware.policy = 'KEY_WORKER'
+          res.locals.policyName = 'key worker'
+          res.locals.policyPath = 'key-worker'
+          break
+        case 'personal-officer':
+          req.middleware.policy = 'PERSONAL_OFFICER'
+          res.locals.policyName = 'personal officer'
+          res.locals.policyPath = 'personal-officer'
+          break
+        default:
+          return res.notFound()
+      }
 
-      res.locals.prisonConfiguration = await keyworkerApiService.getPrisonConfig(req, prisonCode)
+      req.middleware.prisonConfiguration = await keyworkerApiService.getPrisonConfig(req, prisonCode)
 
-      if (!res.locals.prisonConfiguration.isEnabled) {
+      if (!req.middleware.prisonConfiguration.isEnabled) {
         return res.render('pages/service-not-enabled')
       }
 

--- a/server/routes/allocate-key-workers/controller.ts
+++ b/server/routes/allocate-key-workers/controller.ts
@@ -52,6 +52,6 @@ export class AllocateKeyWorkerController extends ChangeKeyWorkerController {
       cellLocationPrefix: req.body.cellLocationPrefix || '',
       excludeActiveAllocations: req.body.excludeActiveAllocations || false,
     })
-    return res.redirect(`/allocate-key-workers?${params.toString()}`)
+    return res.redirect(`/${res.locals.policyPath}/allocate-key-workers?${params.toString()}`)
   }
 }

--- a/server/routes/allocate-key-workers/tests.cy.ts
+++ b/server/routes/allocate-key-workers/tests.cy.ts
@@ -55,11 +55,13 @@ context('/allocate-key-workers', () => {
   it('should handle invalid queries', () => {
     navigateToTestPage()
 
-    cy.visit('/allocate-key-workers?query=<script>alert%28%27inject%27%29<%2Fscript>', { failOnStatusCode: false })
+    cy.visit('/key-worker/allocate-key-workers?query=<script>alert%28%27inject%27%29<%2Fscript>', {
+      failOnStatusCode: false,
+    })
     cy.findByRole('textbox', { name: /Name or prison number/ }).should('have.value', '')
     cy.get('.govuk-table__row').should('have.length', 4)
 
-    cy.visit('/allocate-key-workers?cellLocationPrefix=<script>alert%28%27inject%27%29<%2Fscript>', {
+    cy.visit('/key-worker/allocate-key-workers?cellLocationPrefix=<script>alert%28%27inject%27%29<%2Fscript>', {
       failOnStatusCode: false,
     })
     cy.findByRole('combobox', { name: /Residential location/ }).should('have.value', '')
@@ -79,21 +81,21 @@ context('/allocate-key-workers', () => {
 
   it('should preserve queries on submit form validation error', () => {
     navigateToTestPage()
-    cy.visit('/allocate-key-workers?excludeActiveAllocations=true', {
+    cy.visit('/key-worker/allocate-key-workers?excludeActiveAllocations=true', {
       failOnStatusCode: false,
     })
 
     cy.findByRole('button', { name: /Save changes/i }).click()
     cy.findByRole('link', { name: /Select key workers from the dropdown lists/ }).should('be.visible')
 
-    cy.url().should('match', /\/allocate-key-workers\?excludeActiveAllocations=true#$/)
+    cy.url().should('match', /\/key-worker\/allocate-key-workers\?excludeActiveAllocations=true#$/)
   })
 
   it('should show error on de/allocation failure', () => {
     cy.task('stubPutAllocationFail')
     navigateToTestPage()
 
-    cy.visit('/allocate-key-workers?query=John', { failOnStatusCode: false })
+    cy.visit('/key-worker/allocate-key-workers?query=John', { failOnStatusCode: false })
 
     cy.get('.govuk-table__row').should('have.length', 2)
     cy.get('.govuk-table__row').eq(1).children().eq(0).should('contain.text', 'John, Doe')
@@ -122,7 +124,7 @@ context('/allocate-key-workers', () => {
     cy.task('stubPutDeallocationSuccess')
     navigateToTestPage()
 
-    cy.visit('/allocate-key-workers?query=John', { failOnStatusCode: false })
+    cy.visit('/key-worker/allocate-key-workers?query=John', { failOnStatusCode: false })
 
     cy.get('.govuk-table__row').should('have.length', 2)
     cy.get('.govuk-table__row').eq(1).children().eq(0).should('contain.text', 'John, Doe')
@@ -151,7 +153,7 @@ context('/allocate-key-workers', () => {
     cy.task('stubPutDeallocationSuccess')
     navigateToTestPage()
 
-    cy.visit('/allocate-key-workers', { failOnStatusCode: false })
+    cy.visit('/key-worker/allocate-key-workers', { failOnStatusCode: false })
 
     cy.get('.govuk-table__row').should('have.length', 4)
     cy.get('.govuk-table__row').eq(2).children().eq(0).should('contain.text', 'John, Doe')
@@ -253,7 +255,7 @@ context('/allocate-key-workers', () => {
       .should('contain.text', 'View allocation history')
       .children()
       .eq(0)
-      .should('have.attr', 'href', '/prisoner-allocation-history/A4288DZ')
+      .should('have.attr', 'href', '/key-worker/prisoner-allocation-history/A4288DZ')
 
     if (!readonly) {
       cy.get('.govuk-table__row')
@@ -307,7 +309,7 @@ context('/allocate-key-workers', () => {
       .should(
         'have.attr',
         'href',
-        '/prisoner-allocation-history/A2504EA?query=&cellLocationPrefix=&excludeActiveAllocations=true',
+        '/key-worker/prisoner-allocation-history/A2504EA?query=&cellLocationPrefix=&excludeActiveAllocations=true',
       )
 
     cy.get('.govuk-table__row').eq(2).children().eq(0).should('contain.text', 'Tester, Jane')
@@ -355,7 +357,7 @@ context('/allocate-key-workers', () => {
       .should(
         'have.attr',
         'href',
-        '/prisoner-allocation-history/A2504EA?query=&cellLocationPrefix=3&excludeActiveAllocations=false',
+        '/key-worker/prisoner-allocation-history/A2504EA?query=&cellLocationPrefix=3&excludeActiveAllocations=false',
       )
   }
 
@@ -379,12 +381,12 @@ context('/allocate-key-workers', () => {
       .should(
         'have.attr',
         'href',
-        '/prisoner-allocation-history/A4288DZ?query=John&cellLocationPrefix=&excludeActiveAllocations=false',
+        '/key-worker/prisoner-allocation-history/A4288DZ?query=John&cellLocationPrefix=&excludeActiveAllocations=false',
       )
   }
 
   const navigateToTestPage = () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit('/allocate-key-workers', { failOnStatusCode: false })
+    cy.visit('/key-worker/allocate-key-workers', { failOnStatusCode: false })
   }
 })

--- a/server/routes/allocate-key-workers/view.njk
+++ b/server/routes/allocate-key-workers/view.njk
@@ -22,7 +22,7 @@
     <div class="govuk-grid-row">
 
       <div class="govuk-grid-column-three-quarters">
-        <form method="post" action="/allocate-key-workers/filter" class="govuk-grid-row govuk-!-margin-bottom-7 govuk-!-padding-6 search-form">
+        <form method="post" action="/{{ policyPath }}/allocate-key-workers/filter" class="govuk-grid-row govuk-!-margin-bottom-7 govuk-!-padding-6 search-form">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
           <h2 class="govuk-heading-m">Filter by</h2>
           <div class="horizontal-form">
@@ -110,7 +110,7 @@
             })
           } if user.permissions.allocate else undefined,
           {
-            html: '<a class="govuk-link govuk-link--no-visited-state" href="/prisoner-allocation-history/' + item.personIdentifier + searchQuery + '">View allocation history</a>' if item.hasAllocationHistory else ''
+            html: '<a class="govuk-link govuk-link--no-visited-state" href="/' + policyPath + '/prisoner-allocation-history/' + item.personIdentifier + searchQuery + '">View allocation history</a>' if item.hasAllocationHistory else ''
           }
         ] | removeUndefined), rows) %}
       {% endfor %}

--- a/server/routes/controller.ts
+++ b/server/routes/controller.ts
@@ -1,9 +1,9 @@
 import { Request, Response } from 'express'
 
 export class HomePageController {
-  GET = async (_req: Request, res: Response) => {
+  GET = async (req: Request, res: Response) => {
     res.locals.breadcrumbs.popLastItem()
-    const { hasPrisonersWithHighComplexityNeeds } = res.locals.prisonConfiguration
+    const { hasPrisonersWithHighComplexityNeeds } = req.middleware!.prisonConfiguration!
 
     return res.render('view', {
       showBreadcrumbs: true,

--- a/server/routes/establishment-settings/controller.ts
+++ b/server/routes/establishment-settings/controller.ts
@@ -7,19 +7,19 @@ export class EstablishmentSettingsController {
   constructor(private readonly keyworkerApiService: KeyworkerApiService) {}
 
   GET = async (req: Request, res: Response) => {
-    const { allowAutoAllocate, capacityTier1, capacityTier2, kwSessionFrequencyInWeeks } =
-      res.locals.prisonConfiguration
+    const { allowAutoAllocation, capacity, maximumCapacity, frequencyInWeeks } = req.middleware!.prisonConfiguration!
 
     res.render('establishment-settings/view', {
+      showBreadcrumbs: true,
       prisonName: res.locals.user.activeCaseLoad!.description,
       allowAutoAllocation:
         res.locals.formResponses?.['allowAutoAllocation'] === undefined
-          ? allowAutoAllocate
+          ? allowAutoAllocation
           : res.locals.formResponses?.['allowAutoAllocation'] === 'TRUE',
-      maximumCapacity: res.locals.formResponses?.['maximumCapacity'] ?? capacityTier2 ?? capacityTier1,
+      maximumCapacity: res.locals.formResponses?.['maximumCapacity'] ?? maximumCapacity ?? capacity,
       frequencyInWeeks:
         res.locals.formResponses?.['frequencyInWeeks'] === undefined
-          ? kwSessionFrequencyInWeeks
+          ? frequencyInWeeks
           : parseFrequencyInWeeks(res.locals.formResponses?.['frequencyInWeeks']),
       isAdmin: res.locals.user.permissions.admin,
       successMessage: req.flash(FLASH_KEY__SUCCESS_MESSAGE)[0],

--- a/server/routes/establishment-settings/tests.cy.ts
+++ b/server/routes/establishment-settings/tests.cy.ts
@@ -94,7 +94,10 @@ context('/establishment-settings', () => {
     cy.findByRole('radio', { name: 'Yes' }).should('exist').and('be.checked')
     getCapacityInput().should('be.visible').and('have.value', '9')
     cy.findByRole('button', { name: 'Save' }).should('be.visible')
-    cy.findByRole('button', { name: 'Cancel' }).should('be.visible').and('have.attr', 'href').should('equal', '/')
+    cy.findByRole('button', { name: 'Cancel' })
+      .should('be.visible')
+      .and('have.attr', 'href')
+      .should('equal', '/key-worker')
   }
 
   const verifyValidationErrors = () => {
@@ -109,6 +112,6 @@ context('/establishment-settings', () => {
 
   const navigateToTestPage = () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit('/establishment-settings', { failOnStatusCode: false })
+    cy.visit('/key-worker/establishment-settings', { failOnStatusCode: false })
   }
 })

--- a/server/routes/establishment-settings/view.njk
+++ b/server/routes/establishment-settings/view.njk
@@ -124,7 +124,7 @@
             {{ govukButton({
               text: "Cancel",
               classes: "govuk-button--secondary",
-              href: "/",
+              href: "/" + policyPath,
               preventDoubleClick: true
             }) }}
           </div>

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,5 +1,3 @@
-import { type RequestHandler, Router } from 'express'
-import asyncMiddleware from '../middleware/asyncMiddleware'
 import type { Services } from '../services'
 import { HomePageController } from './controller'
 import { KeyWorkerStatisticsRoutes } from './key-worker-statistics/routes'
@@ -13,24 +11,28 @@ import JourneyRoutes from './journeys/routes'
 import { dataAccess } from '../data'
 import { EstablishmentSettingsRoutes } from './establishment-settings/routes'
 import { KeyWorkersDataRoutes } from './key-workers-data/routes'
-import { populatePolicy } from '../middleware/populatePolicy'
+import { populateUserPermissions } from '../middleware/permissionsMiddleware'
+import { JourneyRouter } from './base/routes'
+import breadcrumbs from '../middleware/breadcrumbs'
 
-export default function routes(services: Services): Router {
-  const router = Router()
+export default function routes(services: Services) {
+  const { router, get } = JourneyRouter()
   const controller = new HomePageController()
-  const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
+
+  router.use(populateUserPermissions())
+  router.use(breadcrumbs())
 
   get('/', controller.GET)
 
   router.use(removeTrailingSlashMiddleware)
 
   router.use('/key-worker-statistics', KeyWorkerStatisticsRoutes(services))
-  router.use('/:policy/manage-key-workers', populatePolicy, KeyWorkerMembersRoutes(services))
   router.use('/key-worker-profile/:staffId', KeyWorkerProfileRoutes(services))
   router.use('/allocate-key-workers', AllocateKeyWorkerRoutes(services))
   router.use('/prisoner-allocation-history', PrisonerAllocationHistoryRoutes(services))
   router.use('/establishment-settings', EstablishmentSettingsRoutes(services))
   router.use('/key-workers-data', KeyWorkersDataRoutes(services))
+  router.use('/manage-key-workers', KeyWorkerMembersRoutes(services))
 
   router.use(insertJourneyIdentifier())
   router.use('/:journeyId', JourneyRoutes(dataAccess(), services))

--- a/server/routes/journeys/assign-staff-role/controller.ts
+++ b/server/routes/journeys/assign-staff-role/controller.ts
@@ -30,7 +30,7 @@ export class AssignStaffRoleController {
     }
 
     return res.render('assign-staff-role/view', {
-      backUrl: '/',
+      backUrl: `/${res.locals.policyPath}`,
       query: req.journeyData.assignStaffRole!.query,
       searchResults: req.journeyData.assignStaffRole!.searchResults,
     })

--- a/server/routes/journeys/assign-staff-role/tests.cy.ts
+++ b/server/routes/journeys/assign-staff-role/tests.cy.ts
@@ -63,7 +63,7 @@ context('/assign-staff-role', () => {
   const navigateToTestPage = () => {
     journeyId = uuidV4()
     cy.signIn({ failOnStatusCode: false })
-    cy.visit(`/${journeyId}/key-worker/assign-staff-role`, {
+    cy.visit(`/key-worker/${journeyId}/assign-staff-role`, {
       failOnStatusCode: false,
     })
   }

--- a/server/routes/journeys/routes.ts
+++ b/server/routes/journeys/routes.ts
@@ -4,7 +4,6 @@ import { Services } from '../../services'
 import setUpJourneyData from '../../middleware/journey/setUpJourneyData'
 import { StartUpdateKeyWorkerRoutes } from './start-update-key-worker/routes'
 import { UpdateCapacityAndStatusRoutes } from './update-capacity-status/routes'
-import { populatePolicy } from '../../middleware/populatePolicy'
 import { AssignStaffRoleRoutes } from './assign-staff-role/routes'
 
 export default function JourneyRoutes(dataAccess: DataAccess, services: Services) {
@@ -15,7 +14,7 @@ export default function JourneyRoutes(dataAccess: DataAccess, services: Services
   router.use('/start-update-key-worker/:staffId', StartUpdateKeyWorkerRoutes(services))
   router.use('/update-capacity-status', UpdateCapacityAndStatusRoutes(services))
 
-  router.use('/:policy/assign-staff-role', populatePolicy, AssignStaffRoleRoutes(services))
+  router.use('/assign-staff-role', AssignStaffRoleRoutes(services))
 
   if (process.env.NODE_ENV === 'e2e-test') {
     /* eslint-disable no-param-reassign */

--- a/server/routes/journeys/update-capacity-status/cancel/tests.cy.ts
+++ b/server/routes/journeys/update-capacity-status/cancel/tests.cy.ts
@@ -14,11 +14,11 @@ context('/update-capacity-status/cancel', () => {
 
   it('should cancel to /update-capacity-status page', () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit(`/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
+    cy.visit(`/key-worker/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
       failOnStatusCode: false,
     })
 
-    cy.visit(`/${journeyId}/update-capacity-status/cancel`)
+    cy.visit(`/key-worker/${journeyId}/update-capacity-status/cancel`)
 
     cy.url().should('match', /\/update-capacity-status$/)
   })

--- a/server/routes/journeys/update-capacity-status/check-answers/tests.cy.ts
+++ b/server/routes/journeys/update-capacity-status/check-answers/tests.cy.ts
@@ -118,12 +118,12 @@ context('/update-capacity-status/check-answers', () => {
     journeyId = uuidV4()
 
     cy.signIn({ failOnStatusCode: false })
-    cy.visit(`/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
+    cy.visit(`/key-worker/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
       failOnStatusCode: false,
     })
 
     cy.injectJourneyDataAndReload<PartialJourneyData>(journeyId, journeyData)
 
-    cy.visit(`/${journeyId}/update-capacity-status/check-answers`)
+    cy.visit(`/key-worker/${journeyId}/update-capacity-status/check-answers`)
   }
 })

--- a/server/routes/journeys/update-capacity-status/controller.ts
+++ b/server/routes/journeys/update-capacity-status/controller.ts
@@ -24,7 +24,7 @@ export class UpdateCapacityAndStatusController {
         value: code,
         text: description,
       })),
-      backUrl: `/key-worker-profile/${req.journeyData.keyWorkerDetails!.keyworker.staffId}`,
+      backUrl: `/${res.locals.policyPath}/key-worker-profile/${req.journeyData.keyWorkerDetails!.keyworker.staffId}`,
       successMessage: req.flash(FLASH_KEY__SUCCESS_MESSAGE)[0],
     })
   }

--- a/server/routes/journeys/update-capacity-status/e2e.cy.ts
+++ b/server/routes/journeys/update-capacity-status/e2e.cy.ts
@@ -136,7 +136,7 @@ context('/update-capacity-status/** journey', () => {
   const beginJourney = () => {
     journeyId = uuidV4()
     cy.signIn({ failOnStatusCode: false })
-    cy.visit(`/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
+    cy.visit(`/key-worker/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
       failOnStatusCode: false,
     })
   }

--- a/server/routes/journeys/update-capacity-status/tests.cy.ts
+++ b/server/routes/journeys/update-capacity-status/tests.cy.ts
@@ -73,7 +73,7 @@ context('Update capacity and status', () => {
 
   const navigateToTestPage = () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit(`/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
+    cy.visit(`/key-worker/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
       failOnStatusCode: false,
     })
   }

--- a/server/routes/journeys/update-capacity-status/update-status-annual-leave-return/tests.cy.ts
+++ b/server/routes/journeys/update-capacity-status/update-status-annual-leave-return/tests.cy.ts
@@ -78,7 +78,7 @@ context('/update-capacity-status/update-status-unavailable', () => {
 
   const navigateToTestPage = () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit(`/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
+    cy.visit(`/key-worker/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
       failOnStatusCode: false,
     })
 
@@ -94,6 +94,6 @@ context('/update-capacity-status/update-status-unavailable', () => {
       },
     })
 
-    cy.visit(`/${journeyId}/update-capacity-status/update-status-annual-leave-return`)
+    cy.visit(`/key-worker/${journeyId}/update-capacity-status/update-status-annual-leave-return`)
   }
 })

--- a/server/routes/journeys/update-capacity-status/update-status-inactive/tests.cy.ts
+++ b/server/routes/journeys/update-capacity-status/update-status-inactive/tests.cy.ts
@@ -49,7 +49,7 @@ context('/update-capacity-status/update-status-inactive', () => {
 
   const navigateToTestPage = () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit(`/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
+    cy.visit(`/key-worker/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
       failOnStatusCode: false,
     })
 
@@ -63,6 +63,6 @@ context('/update-capacity-status/update-status-inactive', () => {
       },
     })
 
-    cy.visit(`/${journeyId}/update-capacity-status/update-status-inactive`)
+    cy.visit(`/key-worker/${journeyId}/update-capacity-status/update-status-inactive`)
   }
 })

--- a/server/routes/journeys/update-capacity-status/update-status-unavailable/tests.cy.ts
+++ b/server/routes/journeys/update-capacity-status/update-status-unavailable/tests.cy.ts
@@ -94,7 +94,7 @@ context('/update-capacity-status/update-status-unavailable', () => {
     journeyId = uuidV4()
 
     cy.signIn({ failOnStatusCode: false })
-    cy.visit(`/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
+    cy.visit(`/key-worker/${journeyId}/start-update-key-worker/488095?proceedTo=update-capacity-status`, {
       failOnStatusCode: false,
     })
 
@@ -108,6 +108,6 @@ context('/update-capacity-status/update-status-unavailable', () => {
       },
     })
 
-    cy.visit(`/${journeyId}/update-capacity-status/update-status-unavailable`)
+    cy.visit(`/key-worker/${journeyId}/update-capacity-status/update-status-unavailable`)
   }
 })

--- a/server/routes/key-worker-profile/tests.cy.ts
+++ b/server/routes/key-worker-profile/tests.cy.ts
@@ -46,7 +46,7 @@ context('Profile Info', () => {
     cy.task('stubPutAllocationFail')
     navigateToTestPage()
 
-    cy.visit('/key-worker-profile/488095', { failOnStatusCode: false })
+    cy.visit('/key-worker/key-worker-profile/488095', { failOnStatusCode: false })
 
     cy.get('.govuk-table__row').should('have.length', 3)
     cy.get('.govuk-table__row').eq(2).children().eq(0).should('contain.text', 'John, Doe')
@@ -74,7 +74,7 @@ context('Profile Info', () => {
     cy.task('stubPutDeallocationSuccess')
     navigateToTestPage()
 
-    cy.visit('/key-worker-profile/488095', { failOnStatusCode: false })
+    cy.visit('/key-worker/key-worker-profile/488095', { failOnStatusCode: false })
 
     cy.get('.govuk-table__row').should('have.length', 3)
     cy.get('.govuk-table__row').eq(2).children().eq(0).should('contain.text', 'John, Doe')
@@ -102,7 +102,7 @@ context('Profile Info', () => {
     cy.task('stubPutDeallocationSuccess')
     navigateToTestPage()
 
-    cy.visit('/key-worker-profile/488095', { failOnStatusCode: false })
+    cy.visit('/key-worker/key-worker-profile/488095', { failOnStatusCode: false })
 
     cy.get('.govuk-table__row').should('have.length', 3)
     cy.get('.govuk-table__row').eq(2).children().eq(0).should('contain.text', 'John, Doe')
@@ -137,7 +137,7 @@ context('Profile Info', () => {
 
   const navigateToTestPage = () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit('/key-worker-profile/488095', { failOnStatusCode: false })
+    cy.visit('/key-worker/key-worker-profile/488095', { failOnStatusCode: false })
   }
 
   const validatePageContents = (readonly = false) => {

--- a/server/routes/key-worker-profile/view.njk
+++ b/server/routes/key-worker-profile/view.njk
@@ -23,7 +23,7 @@
       <h1 class="govuk-heading-l govuk-!-display-inline-block govuk-!-margin-0">{{ keyworker | firstNameSpaceLastName }}</h1>
       <p class="govuk-!-margin-left-2 govuk-!-display-inline-block govuk-!-margin-0 "> {{ statusTag({ text: status.description }) }} </p>
       {% if user.permissions.allocate %}
-        <a class="govuk-!-margin-left-2 govuk-link govuk-link--no-visited-state govuk-!-display-inline-block " href="/start-update-key-worker/{{ keyworker.staffId }}?proceedTo=update-capacity-status">Update capacity and status</a>
+        <a class="govuk-!-margin-left-2 govuk-link govuk-link--no-visited-state govuk-!-display-inline-block " href="../start-update-key-worker/{{ keyworker.staffId }}?proceedTo=update-capacity-status">Update capacity and status</a>
       {% endif %}
     </div>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />

--- a/server/routes/key-worker-statistics/controller.ts
+++ b/server/routes/key-worker-statistics/controller.ts
@@ -109,8 +109,8 @@ export class KeyWorkerStatisticsController {
       data,
       hasCurrentStats,
       hasPreviousStats,
-      prisonerToKeyWorkerRatio: prison.capacityTier1,
-      weekFrequency: prison.kwSessionFrequencyInWeeks,
+      prisonerToKeyWorkerRatio: prison.capacity,
+      weekFrequency: prison.frequencyInWeeks,
       dateFrom: formatDateConcise(nowSpan.start),
       dateTo: formatDateConcise(nowSpan.end),
       comparisonDateFrom: formatDateConcise(previousSpan.start),
@@ -122,6 +122,6 @@ export class KeyWorkerStatisticsController {
   POST = async (req: Request<unknown, unknown, SchemaType>, res: Response): Promise<void> => {
     // Date entry is updated - reload this page with the latest data
     req.flash(FLASH_KEY__FORM_RESPONSES, JSON.stringify({ start: req.body.dateFrom, end: req.body.dateTo }))
-    return res.redirect('/key-worker-statistics')
+    return res.redirect('key-worker-statistics')
   }
 }

--- a/server/routes/key-worker-statistics/tests.cy.ts
+++ b/server/routes/key-worker-statistics/tests.cy.ts
@@ -270,6 +270,6 @@ context('Key worker statistics', () => {
 
   const navigateToTestPage = () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit('/key-worker-statistics', { failOnStatusCode: false })
+    cy.visit('/key-worker/key-worker-statistics', { failOnStatusCode: false })
   }
 })

--- a/server/routes/key-workers-data/controller.ts
+++ b/server/routes/key-workers-data/controller.ts
@@ -159,7 +159,7 @@ export class KeyWorkersDataController {
     const previousSpan = this.getComparisonDates(nowSpan.start, nowSpan.end)
     const prisonCode = res.locals.user.getActiveCaseloadId()!
     const stats = await this.keyworkerApiService.getPrisonStats(req, prisonCode, nowSpan.start, nowSpan.end)
-    const prison = res.locals.prisonConfiguration
+    const prison = req.middleware!.prisonConfiguration!
     const hasPreviousStats = stats.previous !== undefined && stats.previous !== null
     const dataUpdateDate = getDateInReadableFormat(new Date().toISOString())
     const prisonName = res.locals.user.caseLoads?.find(caseLoad => caseLoad.caseLoadId === prisonCode)?.description
@@ -168,7 +168,7 @@ export class KeyWorkersDataController {
       stats.current,
       stats.previous,
       prison.hasPrisonersWithHighComplexityNeeds,
-      prison.kwSessionFrequencyInWeeks,
+      prison.frequencyInWeeks,
     )
 
     res.render('key-workers-data/view', {
@@ -187,6 +187,6 @@ export class KeyWorkersDataController {
   POST = async (req: Request, res: Response) => {
     req.flash(FLASH_KEY__FORM_RESPONSES, JSON.stringify({ start: req.body.dateFrom, end: req.body.dateTo }))
 
-    res.redirect('/key-workers-data')
+    res.redirect('key-workers-data')
   }
 }

--- a/server/routes/key-workers-data/tests.cy.ts
+++ b/server/routes/key-workers-data/tests.cy.ts
@@ -322,7 +322,7 @@ context('Key workers data', () => {
 
   const navigateToTestPage = () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit('/key-workers-data', { failOnStatusCode: false })
+    cy.visit('/key-worker/key-workers-data', { failOnStatusCode: false })
   }
 })
 

--- a/server/routes/manage-key-workers/view.njk
+++ b/server/routes/manage-key-workers/view.njk
@@ -54,7 +54,7 @@
       {% for item in records %}
         {% set rows = (rows.push([
           {
-            html: '<a class="govuk-link--no-visited-state" href="/key-worker-profile/' + item.staffId + '">' + item | lastNameCommaFirstName + "</a>",
+            html: '<a class="govuk-link--no-visited-state" href="key-worker-profile/' + item.staffId + '">' + item | lastNameCommaFirstName + "</a>",
             attributes: {
               "data-sort-value": item | lastNameCommaFirstName
             }

--- a/server/routes/prisoner-allocation-history/controller.ts
+++ b/server/routes/prisoner-allocation-history/controller.ts
@@ -13,7 +13,7 @@ export class PrisonerAllocationHistoryController {
     res.render('prisoner-allocation-history/view', {
       prisoner,
       allocationHistory: keyworkerAllocations.allocations,
-      backUrl: `/allocate-key-workers${searchParams.length > 0 ? `?${searchParams}` : ''}`,
+      backUrl: `/${res.locals.policyPath}/allocate-key-workers${searchParams.length > 0 ? `?${searchParams}` : ''}`,
     })
   }
 }

--- a/server/routes/prisoner-allocation-history/tests.cy.ts
+++ b/server/routes/prisoner-allocation-history/tests.cy.ts
@@ -12,7 +12,7 @@ context('Prisoner Allocation History', () => {
 
   it('redirects to "not found" page if user does not have the correct role', () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit('/prisoner-allocation-history/A9965EB?query=&location=&excludeActiveAllocations=true', {
+    cy.visit('/key-worker/prisoner-allocation-history/A9965EB?query=&location=&excludeActiveAllocations=true', {
       failOnStatusCode: false,
     })
 
@@ -21,21 +21,21 @@ context('Prisoner Allocation History', () => {
 
   it('adds back query params on the back link', () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit('/prisoner-allocation-history/A9965EA?query=&location=&excludeActiveAllocations=true', {
+    cy.visit('/key-worker/prisoner-allocation-history/A9965EA?query=&location=&excludeActiveAllocations=true', {
       failOnStatusCode: false,
     })
 
     cy.findByRole('link', { name: /back/i }).should(
       'have.attr',
       'href',
-      '/allocate-key-workers?query=&location=&excludeActiveAllocations=true',
+      '/key-worker/allocate-key-workers?query=&location=&excludeActiveAllocations=true',
     )
   })
 
   it('happy path', () => {
     navigateToTestPage()
 
-    cy.findByRole('link', { name: /back/i }).should('have.attr', 'href', '/allocate-key-workers')
+    cy.findByRole('link', { name: /back/i }).should('have.attr', 'href', '/key-worker/allocate-key-workers')
 
     cy.get('.govuk-link--no-visited-state').eq(0).should('have.text', 'Cat, Tabby')
     cy.findByText('A9965EA')
@@ -246,6 +246,6 @@ context('Prisoner Allocation History', () => {
 
   const navigateToTestPage = () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit('/prisoner-allocation-history/A9965EA', { failOnStatusCode: false })
+    cy.visit('/key-worker/prisoner-allocation-history/A9965EA', { failOnStatusCode: false })
   }
 })

--- a/server/routes/test.cy.ts
+++ b/server/routes/test.cy.ts
@@ -72,7 +72,7 @@ context('test / homepage', () => {
     cy.get('h2 > .card__link')
       .eq(0)
       .should('contain.text', 'Allocate key workers to prisoners')
-      .and('have.attr', 'href', '/allocate-key-workers')
+      .and('have.attr', 'href', '/key-worker/allocate-key-workers')
     cy.get('.card__description')
       .eq(0)
       .should(
@@ -92,7 +92,7 @@ context('test / homepage', () => {
     cy.get('h2 > .card__link')
       .eq(2)
       .should('contain.text', 'View key worker data')
-      .and('have.attr', 'href', '/key-workers-data')
+      .and('have.attr', 'href', '/key-worker/key-workers-data')
     cy.get('.card__description').eq(2).should('contain.text', 'View key worker data for your establishment.')
 
     if (!readonly) {
@@ -106,7 +106,7 @@ context('test / homepage', () => {
       cy.get('h2 > .card__link')
         .eq(4)
         .should('contain.text', 'Manage your establishment’s key worker settings')
-        .and('have.attr', 'href', '/establishment-settings')
+        .and('have.attr', 'href', '/key-worker/establishment-settings')
       cy.get('.card__description')
         .eq(4)
         .should(
@@ -127,6 +127,6 @@ context('test / homepage', () => {
 
   const navigateToTestPage = () => {
     cy.signIn({ failOnStatusCode: false })
-    cy.visit('/', { failOnStatusCode: false })
+    cy.visit('/key-worker', { failOnStatusCode: false })
   }
 })

--- a/server/routes/view.njk
+++ b/server/routes/view.njk
@@ -1,10 +1,10 @@
 {% extends "partials/layout.njk" %}
 
-{% set pageTitle = "Key workers" %}
+{% set pageTitle = policyName | sentenceCase %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l govuk-!-margin-bottom-6">Key workers</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-bottom-6">{{ policyName | sentenceCase }}s</h1>
 
   <div class="homepage-content-container">
     <div class="homepage-content">
@@ -16,7 +16,7 @@
               <div class="govuk-grid-column-one-third card-group__item">
                 <div class="card card--clickable">
                   <h2 class="govuk-heading-m card__heading">
-                    <a class="govuk-link govuk-link--no-visited-state card__link" href="/allocate-key-workers">Allocate key workers to prisoners</a>
+                    <a class="govuk-link govuk-link--no-visited-state card__link" href="/{{ policyPath }}/allocate-key-workers">Allocate key workers to prisoners</a>
                   </h2>
                   <p class="govuk-body card__description">View all prisoners or filter by location or allocation status, search for individuals, and automatically assign key workers.</p>
                 </div>
@@ -25,7 +25,7 @@
               <div class="govuk-grid-column-one-third card-group__item">
                 <div class="card card--clickable">
                   <h2 class="govuk-heading-m card__heading">
-                    <a class="govuk-link govuk-link--no-visited-state card__link" href="/key-worker/manage-key-workers">Manage key workers</a>
+                    <a class="govuk-link govuk-link--no-visited-state card__link" href="/{{ policyPath }}/manage-key-workers">Manage key workers</a>
                   </h2>
                   <p class="govuk-body card__description">View key workers, change their status and capacity, and view and reassign their prisoners.</p>
                 </div>
@@ -34,7 +34,7 @@
               <div class="govuk-grid-column-one-third card-group__item">
                 <div class="card card--clickable">
                   <h2 class="govuk-heading-m card__heading">
-                    <a class="govuk-link govuk-link--no-visited-state card__link" href="/key-workers-data">View key worker data</a>
+                    <a class="govuk-link govuk-link--no-visited-state card__link" href="/{{ policyPath }}/key-workers-data">View key worker data</a>
                   </h2>
                   <p class="govuk-body card__description">View key worker data for your establishment.</p>
                 </div>
@@ -44,7 +44,7 @@
                 <div class="govuk-grid-column-one-third card-group__item">
                   <div class="card card--clickable">
                     <h2 class="govuk-heading-m card__heading">
-                      <a class="govuk-link govuk-link--no-visited-state card__link" href="/key-worker/assign-staff-role">Make someone a key worker</a>
+                      <a class="govuk-link govuk-link--no-visited-state card__link" href="/{{ policyPath }}/assign-staff-role">Make someone a key worker</a>
                     </h2>
                     <p class="govuk-body card__description">Assign the key worker role to staff members in your establishment.</p>
                   </div>
@@ -53,7 +53,7 @@
                 <div class="govuk-grid-column-one-third card-group__item">
                   <div class="card card--clickable">
                     <h2 class="govuk-heading-m card__heading">
-                      <a class="govuk-link govuk-link--no-visited-state card__link" href="/establishment-settings">Manage your establishment’s key worker settings</a>
+                      <a class="govuk-link govuk-link--no-visited-state card__link" href="/{{ policyPath }}/establishment-settings">Manage your establishment’s key worker settings</a>
                     </h2>
                     <p class="govuk-body card__description">Enable automatic assignment of key workers, set capacity and view session frequency settings.</p>
                   </div>

--- a/server/services/keyworkerApi/keyworkerApiClient.ts
+++ b/server/services/keyworkerApi/keyworkerApiClient.ts
@@ -70,9 +70,9 @@ export default class KeyworkerApiClient {
     return response
   }
 
-  async getPrisonConfig(prisonCode: string): Promise<components['schemas']['PrisonKeyworkerConfiguration']> {
-    const response = await this.restClient.get<components['schemas']['PrisonKeyworkerConfiguration']>({
-      path: `/prisons/${prisonCode}/configuration/keyworker`,
+  async getPrisonConfig(prisonCode: string): Promise<components['schemas']['PrisonConfigResponse']> {
+    const response = await this.restClient.get<components['schemas']['PrisonConfigResponse']>({
+      path: `/prisons/${prisonCode}/configurations`,
     })
 
     return response

--- a/server/services/keyworkerApi/keyworkerApiService.ts
+++ b/server/services/keyworkerApi/keyworkerApiService.ts
@@ -34,7 +34,7 @@ export default class KeyworkerApiService {
     maximumCapacity: number,
     frequencyInWeeks?: number,
   ) {
-    const config = res.locals.prisonConfiguration
+    const config = req.middleware!.prisonConfiguration!
 
     const requestBody = {
       isEnabled: config.isEnabled,
@@ -42,7 +42,7 @@ export default class KeyworkerApiService {
       allowAutoAllocation,
       maximumCapacity,
       capacity: maximumCapacity,
-      frequencyInWeeks: frequencyInWeeks ?? config.kwSessionFrequencyInWeeks,
+      frequencyInWeeks: frequencyInWeeks ?? config.frequencyInWeeks,
     }
 
     return this.keyworkerApiClientBuilder(req).updatePrisonConfig(res.locals.user.getActiveCaseloadId()!, requestBody)


### PR DESCRIPTION
MIA-426

this completes the following a/c: 

1. All UI routes start with /:policy of which there are two valid options:
key-worker
personal-officer

2. All API calls should include the Policy header of which there are two valid options
KEY_WORKER
PERSONAL_OFFICER

4a. Call new policy aware prison config endpoint
 
4b. prisonConfiguration should be moved to req.middleware as it is not needed in views