### PR TITLE
Fix update staff status api calls

### DIFF
--- a/server/routes/journeys/update-capacity-status-and-working-pattern/check-answers/controller.ts
+++ b/server/routes/journeys/update-capacity-status-and-working-pattern/check-answers/controller.ts
@@ -27,12 +27,13 @@ export class UpdateStatusCheckAnswersController {
       if (status!.code === 'ACTIVE') {
         await this.keyworkerApiService.upsertStaffDetails(req as Request, res, req.journeyData.staffDetails!.staffId, {
           status: status!.code,
+          reactivateOn: null,
         })
       } else {
         await this.keyworkerApiService.upsertStaffDetails(req as Request, res, req.journeyData.staffDetails!.staffId, {
           status: status!.code,
           deactivateActiveAllocations: deactivateActiveAllocations!,
-          ...(status?.code === 'UNAVAILABLE_ANNUAL_LEAVE' ? { reactivateOn } : {}),
+          reactivateOn: status?.code === 'UNAVAILABLE_ANNUAL_LEAVE' ? reactivateOn! : null,
         })
       }
 

--- a/server/routes/journeys/update-capacity-status-and-working-pattern/e2e.cy.ts
+++ b/server/routes/journeys/update-capacity-status-and-working-pattern/e2e.cy.ts
@@ -45,6 +45,7 @@ context('/update-capacity-status-and-working-pattern/** journey', () => {
       { method: 'PUT', urlPath: '/keyworker-api/prisons/LEI/staff/488095' },
       {
         status: 'ACTIVE',
+        reactivateOn: null,
       },
     )
   })
@@ -67,6 +68,7 @@ context('/update-capacity-status-and-working-pattern/** journey', () => {
       { method: 'PUT', urlPath: '/keyworker-api/prisons/LEI/staff/488095' },
       {
         status: 'INACTIVE',
+        reactivateOn: null,
         deactivateActiveAllocations: true,
       },
     )
@@ -104,6 +106,7 @@ context('/update-capacity-status-and-working-pattern/** journey', () => {
       {
         status: 'UNAVAILABLE_LONG_TERM_ABSENCE',
         deactivateActiveAllocations: false,
+        reactivateOn: null,
       },
     )
   })

--- a/server/routes/journeys/update-capacity-status-and-working-pattern/update-status-inactive/controller.ts
+++ b/server/routes/journeys/update-capacity-status-and-working-pattern/update-status-inactive/controller.ts
@@ -18,6 +18,7 @@ export class UpdateStatusInactiveController {
     try {
       await this.keyworkerApiService.upsertStaffDetails(req as Request, res, req.journeyData.staffDetails!.staffId, {
         status: req.journeyData.updateStaffDetails!.status!.code,
+        reactivateOn: null,
         deactivateActiveAllocations: true,
       })
 

--- a/server/routes/journeys/update-capacity-status-and-working-pattern/update-status-inactive/tests.cy.ts
+++ b/server/routes/journeys/update-capacity-status-and-working-pattern/update-status-inactive/tests.cy.ts
@@ -26,6 +26,7 @@ context('/update-capacity-status-and-working-pattern/update-status-inactive', ()
       { method: 'PUT', urlPath: '/keyworker-api/prisons/LEI/staff/488095' },
       {
         status: 'INACTIVE',
+        reactivateOn: null,
         deactivateActiveAllocations: true,
       },
     )


### PR DESCRIPTION
upon setting staff status to anything other than Unavailable - Annual leave, unset staff's return date.